### PR TITLE
Incorporate Flow types into source code

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/flow-typed/npm/redux_v4.x.x.js
+++ b/flow-typed/npm/redux_v4.x.x.js
@@ -1,0 +1,100 @@
+// flow-typed signature: a49a6c96fe8a8bb3330cce2028588f4c
+// flow-typed version: de5b3a01c6/redux_v4.x.x/flow_>=v0.89.x
+
+declare module 'redux' {
+  /*
+
+    S = State
+    A = Action
+    D = Dispatch
+
+  */
+
+  declare export type Action<T> = {
+    type: T
+  }
+
+  declare export type DispatchAPI<A> = (action: A) => A;
+
+  declare export type Dispatch<A: { type: * }> = DispatchAPI<A>;
+
+  declare export type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+    dispatch: D,
+    getState(): S,
+  };
+
+  declare export type Store<S, A, D = Dispatch<A>> = {
+    // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
+    dispatch: D,
+    getState(): S,
+    subscribe(listener: () => void): () => void,
+    replaceReducer(nextReducer: Reducer<S, A>): void,
+  };
+
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
+
+  declare export type CombinedReducer<S, A> = (
+    state: ($Shape<S> & {}) | void,
+    action: A
+  ) => S;
+
+  declare export type Middleware<S, A, D = Dispatch<A>> = (
+    api: MiddlewareAPI<S, A, D>
+  ) => (next: D) => D;
+
+  declare export type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>,
+    (
+      reducer: Reducer<S, A>,
+      preloadedState: S,
+      enhancer?: StoreEnhancer<S, A, D>
+    ): Store<S, A, D>,
+  };
+
+  declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (
+    next: StoreCreator<S, A, D>
+  ) => StoreCreator<S, A, D>;
+
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+  declare export function createStore<S, A, D>(
+    reducer: Reducer<S, A>,
+    preloadedState?: S,
+    enhancer?: StoreEnhancer<S, A, D>
+  ): Store<S, A, D>;
+
+  declare export function applyMiddleware<S, A, D>(
+    ...middlewares: Array<Middleware<S, A, D>>
+  ): StoreEnhancer<S, A, D>;
+
+  declare export type ActionCreator<A, B> = (...args: Array<B>) => A;
+  declare export type ActionCreators<K, A> = {
+    [key: K]: ActionCreator<A, any>,
+  };
+
+  declare export function bindActionCreators<
+    A,
+    C: ActionCreator<A, any>,
+    D: DispatchAPI<A>
+  >(
+    actionCreator: C,
+    dispatch: D
+  ): C;
+  declare export function bindActionCreators<
+    A,
+    K,
+    C: ActionCreators<K, A>,
+    D: DispatchAPI<A>
+  >(
+    actionCreators: C,
+    dispatch: D
+  ): C;
+
+  declare export function combineReducers<O: {}, A>(
+    reducers: O
+  ): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
+
+  declare export var compose: $Compose;
+}

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
     "build-cjs": "rollup src/index.js --format cjs --output dist/index.cjs.js",
     "build-es": "rollup src/index.js --format es --output dist/index.es.js",
     "build": "npm run build-cjs && npm run build-es",
+    "flow": "flow check",
     "prepublishOnly": "npm run build"
   },
   "author": "Giancarlo Anemone",
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "redux": "^3.6.0",
+    "flow-bin": "^0.102.0",
+    "redux": "^4.0.4",
     "rollup": "^0.41.6",
     "tape": "^4.6.3"
   }

--- a/src/index.flow.js
+++ b/src/index.flow.js
@@ -2,21 +2,22 @@
 
 import type {StoreCreator, Action, Reducer} from 'redux';
 
-type ReactorAction<S, T> = {|
+export type ReactorAction<S, T> = {|
   type: T,
-  payload?: mixed,
-  __REACTOR__?: Reducer<S, Action<T>>,
+  payload: mixed,
+  __REACTOR__: Reducer<S, ReactorAction<S, T>>,
 |};
 
 export function reactorEnhancer<
   S,
   ActionType,
-  A: ReactorAction<S, ActionType>,
+  A: Action<ActionType> | ReactorAction<S, ActionType>,
   D
 >(createStore: StoreCreator<S, A, D>): StoreCreator<S, A, D> {
   return function storeCreator(reducer, ...remainingArgs) {
     function wrappedReducer(state: S | void, action: A): S {
       if (action.__REACTOR__) {
+        // $FlowFixMe
         return action.__REACTOR__(state, action);
       }
       return reducer(state, action);
@@ -27,9 +28,9 @@ export function reactorEnhancer<
 
 export function createReactor<S, T>(
   type: T,
-  __REACTOR__: Reducer<S, Action<T>>
+  __REACTOR__: Reducer<S, ReactorAction<S, T>>
 ): (payload: mixed) => ReactorAction<S, T> {
-  return function actionCreator(payload: mixed) {
+  return function actionCreator(payload: mixed): ReactorAction<S, T> {
     return {
       type: type,
       payload: payload,

--- a/src/index.flow.js
+++ b/src/index.flow.js
@@ -1,0 +1,39 @@
+// @flow
+
+import type {StoreCreator, Action, Reducer} from 'redux';
+
+type ReactorAction<S, T> = {|
+  type: T,
+  payload?: mixed,
+  __REACTOR__?: Reducer<S, Action<T>>,
+|};
+
+export function reactorEnhancer<
+  S,
+  ActionType,
+  A: ReactorAction<S, ActionType>,
+  D
+>(createStore: StoreCreator<S, A, D>): StoreCreator<S, A, D> {
+  return function storeCreator(reducer, ...remainingArgs) {
+    function wrappedReducer(state: S | void, action: A): S {
+      if (action.__REACTOR__) {
+        return action.__REACTOR__(state, action);
+      }
+      return reducer(state, action);
+    }
+    return createStore(wrappedReducer, ...remainingArgs);
+  };
+}
+
+export function createReactor<S, T>(
+  type: T,
+  __REACTOR__: Reducer<S, Action<T>>
+): (payload: mixed) => ReactorAction<S, T> {
+  return function actionCreator(payload: mixed) {
+    return {
+      type: type,
+      payload: payload,
+      __REACTOR__: __REACTOR__,
+    };
+  };
+}


### PR DESCRIPTION
Changes:
* Adds `src/index.flow.js` that includes Flow types for exported functions
* Adds default `.flowconfig` and script to `package.json` to allow running `yarn flow`
* Adds `redux` libdef in `flow-typed/` directory to leverage Redux types